### PR TITLE
Fix: Only occupy scroll bar space when content overflows

### DIFF
--- a/components/card.js
+++ b/components/card.js
@@ -33,7 +33,7 @@ export default function Card({ heading, children, footer, actionButton }) {
           justify-content: space-between;
         }
         .content {
-          overflow-y: scroll;
+          overflow-y: auto;
         }
         .footer {
           border-top: var(--dividing-border);


### PR DESCRIPTION
Depending on the OS settings, using `overflow-y: scroll` adds
an empty space when the content does not overflow.

Fixes #3